### PR TITLE
issue #15 - fix inner Map classes serialization

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,11 +6,13 @@ on:
       - master
       - release/velocypack-module-scala_2.11
       - release/velocypack-module-scala_2.12
+      - release/velocypack-module-scala_2.13
   push:
     branches:
       - master
       - release/velocypack-module-scala_2.11
       - release/velocypack-module-scala_2.12
+      - release/velocypack-module-scala_2.13
 
 jobs:
 
@@ -24,7 +26,6 @@ jobs:
         java-version:
           - 8
           - 11
-          - 14
 
     steps:
       - uses: actions/checkout@v1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [velocypack-module-scala_2.13:1.2.0] - 2020-09-22
+
+- support for scala 2.13
+
 ## [1.2.0] - 2020-02-03
 
 - support for scala 2.11 and 2.12

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![ArangoDB-Logo](https://docs.arangodb.com/assets/arangodb_logo_2016_inverted.png)
+![ArangoDB-Logo](https://www.arangodb.com/docs/assets/arangodb_logo_2016_inverted.png)
 
 # ArangoDB VelocyPack Java Module Scala
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.arangodb</groupId>
-	<artifactId>velocypack-module-scala_2.12</artifactId>
+	<artifactId>velocypack-module-scala_2.13</artifactId>
 	<version>1.2.0</version>
 	<inceptionYear>2017</inceptionYear>
 	<packaging>jar</packaging>
@@ -80,7 +80,7 @@
 				<artifactId>sbt-compiler-maven-plugin</artifactId>
 				<version>1.0.0</version>
 				<configuration>
-					<scalaVersion>2.12.12</scalaVersion>
+					<scalaVersion>2.13.1</scalaVersion>
 				</configuration>
 				<executions>
 					<execution>
@@ -185,7 +185,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.scalatest</groupId>
-			<artifactId>scalatest_2.12</artifactId>
+			<artifactId>scalatest_2.13</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -209,8 +209,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.scalatest</groupId>
-				<artifactId>scalatest_2.12</artifactId>
-				<version>3.0.0</version>
+				<artifactId>scalatest_2.13</artifactId>
+				<version>3.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<version>4.13.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>

--- a/src/main/scala/com/arangodb/velocypack/module/scala/VPackScalaModule.scala
+++ b/src/main/scala/com/arangodb/velocypack/module/scala/VPackScalaModule.scala
@@ -29,16 +29,19 @@ class VPackScalaModule extends VPackModule {
       classOf[List[Any]],
       classOf[Vector[Any]],
       classOf[Seq[Any]],
-      Seq(Unit).getClass,
+      Seq(()).getClass,
       Seq.empty.getClass,
       Nil.getClass
     ).foreach(context.registerSerializer(_, VPackScalaSerializers.SEQ))
 
     Set(
-      classOf[HashMap.HashMap1[_, _]],
-      classOf[HashMap.HashTrieMap[_, _]],
+      classOf[Map.Map1[_, _]],
+      classOf[Map.Map2[_, _]],
+      classOf[Map.Map3[_, _]],
+      classOf[Map.Map4[_, _]],
+      classOf[HashMap[_, _]],
       classOf[TreeMap[_, _]],
-      ListMap(Unit -> Unit).getClass,
+      ListMap(() -> ()).getClass,
       classOf[Map[_, _]]
     ).foreach(context.registerSerializer(_, VPackScalaSerializers.MAP))
 

--- a/src/main/scala/com/arangodb/velocypack/module/scala/VPackScalaModule.scala
+++ b/src/main/scala/com/arangodb/velocypack/module/scala/VPackScalaModule.scala
@@ -5,6 +5,8 @@ import com.arangodb.velocypack.VPackSetupContext
 import com.arangodb.velocypack.module.scala.internal.VPackScalaSerializers
 import com.arangodb.velocypack.module.scala.internal.VPackScalaDeserializers
 
+import scala.collection.{MapLike, mutable}
+import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.{HashMap, ListMap, TreeMap}
 
 class VPackScalaModule extends VPackModule {
@@ -25,31 +27,43 @@ class VPackScalaModule extends VPackModule {
 
     // serializers
 
-    Set(
+    Set[Class[_ <: Seq[_]]](
       classOf[List[Any]],
       classOf[Vector[Any]],
       classOf[Seq[Any]],
       Seq(()).getClass,
-      Seq.empty.getClass,
+      Seq.empty[Any].getClass,
       Nil.getClass
     ).foreach(context.registerSerializer(_, VPackScalaSerializers.SEQ))
 
-    Set(
+    Set[Class[_ <: Map[_, _]]](
       classOf[Map.Map1[_, _]],
       classOf[Map.Map2[_, _]],
       classOf[Map.Map3[_, _]],
       classOf[Map.Map4[_, _]],
       classOf[HashMap[_, _]],
+      classOf[HashMap.HashMap1[_, _]],
+      classOf[HashMap.HashTrieMap[_, _]],
       classOf[TreeMap[_, _]],
-      ListMap(() -> ()).getClass,
-      classOf[Map[_, _]]
-    ).foreach(context.registerSerializer(_, VPackScalaSerializers.MAP))
+      Map(() -> ()).withDefault(null).getClass, // inner Map.WithDefault
+      Map(() -> ()).filterKeys(null).getClass, // inner MapLike.FilteredKeys with DefaultMap
+      Map(() -> ()).mapValues(null).getClass, // inner MapLike.MappedValues with DefaultMap
+      ListMap(() -> ()).getClass // inner ListMap.Node
+    ).foreach(context.registerSerializer(_, VPackScalaSerializers.MAP_IMMUTABLE))
 
-    context.registerEnclosingSerializer(classOf[Map[Any, Any]], VPackScalaSerializers.MAP)
+    Set[Class[_ <: mutable.Map[_, _]]](
+      classOf[TrieMap[Any, Any]]
+    ).foreach(context.registerSerializer(_, VPackScalaSerializers.MAP_MUTABLE))
+
+    context.registerEnclosingSerializer(classOf[Map[Any, Any]], VPackScalaSerializers.MAP_IMMUTABLE)
+    context.registerEnclosingSerializer(classOf[MapLike[Any, Any, Any]], VPackScalaSerializers.MAP_IMMUTABLE)
+
+    context.registerEnclosingSerializer(classOf[mutable.Map[Any, Any]], VPackScalaSerializers.MAP_MUTABLE)
+    context.registerEnclosingSerializer(classOf[mutable.MapLike[Any, Any, Any]], VPackScalaSerializers.MAP_MUTABLE)
 
     context.registerSerializer(classOf[BigInt], VPackScalaSerializers.BIG_INT)
-    context.registerSerializer(classOf[Option[Any]], VPackScalaSerializers.OPTION)
     context.registerSerializer(classOf[BigDecimal], VPackScalaSerializers.BIG_DECIMAL)
+    context.registerSerializer(classOf[Option[Any]], VPackScalaSerializers.OPTION)
   }
 
 }

--- a/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaDeserializers.scala
+++ b/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaDeserializers.scala
@@ -5,7 +5,7 @@ import com.arangodb.velocypack.VPackDeserializationContext
 import com.arangodb.velocypack.VPackSlice
 import com.arangodb.velocypack.VPackDeserializerParameterizedType
 import java.lang.reflect.ParameterizedType
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 object VPackScalaDeserializers {
 
@@ -28,7 +28,7 @@ object VPackScalaDeserializers {
 
     def deserialize(parent: VPackSlice, vpack: VPackSlice, context: VPackDeserializationContext, t: ParameterizedType): List[Any] = {
       val clazz = t.getActualTypeArguments()(0).asInstanceOf[Class[Any]]
-      vpack.arrayIterator().map { slice: VPackSlice => context.deserialize[Any](slice, clazz) }.toList
+      vpack.arrayIterator().asScala.map { slice: VPackSlice => context.deserialize[Any](slice, clazz) }.toList
     }
   }
 
@@ -38,13 +38,13 @@ object VPackScalaDeserializers {
 
     def deserialize(parent: VPackSlice, vpack: VPackSlice, context: VPackDeserializationContext, t: ParameterizedType): Vector[Any] = {
       val clazz = t.getActualTypeArguments()(0).asInstanceOf[Class[Any]]
-      vpack.arrayIterator().map { slice: VPackSlice => context.deserialize[Any](slice, clazz) }.toVector
+      vpack.arrayIterator().asScala.map { slice: VPackSlice => context.deserialize[Any](slice, clazz) }.toVector
     }
   }
 
   val MAP = new VPackDeserializer[Map[Any, Any]] {
     def deserialize(parent: VPackSlice, vpack: VPackSlice, context: VPackDeserializationContext): Map[Any, Any] =
-      context.deserialize[java.util.Map[Any, Any]](vpack, classOf[java.util.Map[Any, Any]]).toMap
+      context.deserialize[java.util.Map[Any, Any]](vpack, classOf[java.util.Map[Any, Any]]).asScala.toMap
   }
 
   val BIG_INT = new VPackDeserializer[BigInt] {

--- a/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaSerializers.scala
+++ b/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaSerializers.scala
@@ -4,7 +4,7 @@ import com.arangodb.velocypack.VPackSerializer
 import com.arangodb.velocypack.VPackSerializationContext
 import com.arangodb.velocypack.VPackBuilder
 import scala.collection.mutable.ListBuffer
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 object VPackScalaSerializers {
 
@@ -15,14 +15,14 @@ object VPackScalaSerializers {
 
   val SEQ = new VPackSerializer[Seq[Any]] {
     def serialize(builder: VPackBuilder, attribute: String, value: Seq[Any], context: VPackSerializationContext): Unit = {
-      val list: _root_.java.util.List[Any] = ListBuffer(value: _*)
+      val list: _root_.java.util.List[Any] = ListBuffer(value: _*).asJava
       context.serialize(builder, attribute, list)
     }
   }
 
   val MAP = new VPackSerializer[Map[Any, Any]] {
     def serialize(builder: VPackBuilder, attribute: String, value: Map[Any, Any], context: VPackSerializationContext): Unit =
-      context.serialize(builder, attribute, mapAsJavaMap(value))
+      context.serialize(builder, attribute, value.asJava)
   }
 
   val BIG_INT = new VPackSerializer[BigInt] {

--- a/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaSerializers.scala
+++ b/src/main/scala/com/arangodb/velocypack/module/scala/internal/VPackScalaSerializers.scala
@@ -3,8 +3,10 @@ package com.arangodb.velocypack.module.scala.internal
 import com.arangodb.velocypack.VPackSerializer
 import com.arangodb.velocypack.VPackSerializationContext
 import com.arangodb.velocypack.VPackBuilder
+
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
+import scala.collection.mutable
 
 object VPackScalaSerializers {
 
@@ -20,8 +22,13 @@ object VPackScalaSerializers {
     }
   }
 
-  val MAP = new VPackSerializer[Map[Any, Any]] {
+  val MAP_IMMUTABLE = new VPackSerializer[Map[Any, Any]] {
     def serialize(builder: VPackBuilder, attribute: String, value: Map[Any, Any], context: VPackSerializationContext): Unit =
+      context.serialize(builder, attribute, value.asJava)
+  }
+
+  val MAP_MUTABLE = new VPackSerializer[mutable.Map[Any, Any]] {
+    def serialize(builder: VPackBuilder, attribute: String, value: mutable.Map[Any, Any], context: VPackSerializationContext): Unit =
       context.serialize(builder, attribute, value.asJava)
   }
 

--- a/src/test/scala/com/arangodb/velocypack/module/scala/VPackListTest.scala
+++ b/src/test/scala/com/arangodb/velocypack/module/scala/VPackListTest.scala
@@ -1,7 +1,7 @@
 package com.arangodb.velocypack.module.scala
 
-import org.scalatest.Matchers
-import org.scalatest.FunSuite
+import org.scalatest.funsuite._
+import org.scalatest.matchers._
 import scala.beans.BeanProperty
 import com.arangodb.velocypack.VPack
 import com.arangodb.velocypack.VPackBuilder
@@ -11,7 +11,7 @@ case class ListTestEntity(@BeanProperty var s: List[String] = List(), @BeanPrope
   def this() = this(s = List())
 }
 
-class VPackListTest extends FunSuite with Matchers {
+class VPackListTest extends AnyFunSuite with should.Matchers {
 
   test("serialize list") {
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()
@@ -33,15 +33,15 @@ class VPackListTest extends FunSuite with Matchers {
 
   test("deserialize list") {
     val builder = new VPackBuilder()
-    builder add ValueType.OBJECT
-    builder add ("s", ValueType.ARRAY)
-    builder add "hello world"
+    builder.add(ValueType.OBJECT)
+    builder.add("s", ValueType.ARRAY)
+    builder.add("hello world")
     builder.close
-    builder add ("i", ValueType.ARRAY)
-    builder add new Integer(69)
+    builder.add ("i", ValueType.ARRAY)
+    builder.add(Integer.valueOf(69))
     builder.close
-    builder add ("o", ValueType.ARRAY)
-    builder add ValueType.OBJECT
+    builder.add ("o", ValueType.ARRAY)
+    builder.add(ValueType.OBJECT)
     builder.close
     builder.close
     builder.close

--- a/src/test/scala/com/arangodb/velocypack/module/scala/VPackMapTest.scala
+++ b/src/test/scala/com/arangodb/velocypack/module/scala/VPackMapTest.scala
@@ -1,8 +1,8 @@
 package com.arangodb.velocypack.module.scala
 
-import com.arangodb.velocypack.module.scala.VPackMapTest._
 import com.arangodb.velocypack.{VPack, VPackBuilder, ValueType}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite._
+import org.scalatest.matchers._
 
 import scala.beans.BeanProperty
 import scala.collection.immutable._
@@ -11,7 +11,7 @@ case class MapTestEntity(@BeanProperty var m: Map[String, Any] = Map()) {
   def this() = this(Map())
 }
 
-class VPackMapTest extends FunSuite with Matchers {
+class VPackMapTest extends AnyFunSuite with should.Matchers {
 
   test("serialize map") {
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()
@@ -52,22 +52,28 @@ class VPackMapTest extends FunSuite with Matchers {
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()
 
     val entity = MapTestEntity(m =
-      HashTrieMap("seq" -> Seq(
-        HashTrieMap("foo" -> 42),
-        SortedMap("foo" -> 42),
-        ListMap("foo" -> 42),
-        HashMap("foo" -> 42),
-        Map("foo" -> 42),
-        ListMap.empty,
-        Map.empty
-      )))
+      HashMap( // scala <= 2.12  -> HashTrieMap is in fact used behind the scene when Map size is >= 5
+        "seq" -> Seq(
+          HashMap("foo" -> 42), // scala <= 2.12 -> Map.Map1, Map.Map2, Map.Map3, HashMap4 is in fact used behind the scene when Map size is <5
+          SortedMap("foo" -> 42),
+          ListMap("foo" -> 42),
+          HashMap("foo" -> 42),
+          Map("foo" -> 42),
+          ListMap.empty,
+          Map.empty
+        ),
+        "seq2" -> Seq(Map("foo" -> 42)), // Map.Map1
+        "seq3" -> Seq(Map("foo" -> 42, "foo2" -> 42)), // Map.Map2
+        "seq4" -> Seq(Map("foo" -> 42, "foo2" -> 42, "foo3" -> 42)), // Map.Map3
+        "seq5" -> Seq(Map("foo" -> 42, "foo2" -> 42, "foo3" -> 42, "foo4" -> 42)), // Map.Map4
+      ))
 
     val vpack = vp.serialize(entity)
     vpack should not be null
     vpack.isObject should be(true)
     vpack.size should be(1)
     vpack.get("m").isObject should be(true)
-    vpack.get("m").size should be(1)
+    vpack.get("m").size should be(5)
     vpack.get("m").get("seq").isArray should be(true)
 
     vpack.get("m").get("seq").get(0).isObject should be(true)
@@ -100,14 +106,35 @@ class VPackMapTest extends FunSuite with Matchers {
 
     vpack.get("m").get("seq").get(5).isObject should be(true)
     vpack.get("m").get("seq").get(5).size should be(0)
+
+    vpack.get("m").get("seq2").get(0).isObject should be(true)
+    vpack.get("m").get("seq2").get(0).size should be(1)
+    vpack.get("m").get("seq2").get(0).get("foo").isInt should be(true)
+    vpack.get("m").get("seq2").get(0).get("foo").getAsInt should be(42)
+
+    vpack.get("m").get("seq3").get(0).isObject should be(true)
+    vpack.get("m").get("seq3").get(0).size should be(2)
+    vpack.get("m").get("seq3").get(0).get("foo2").isInt should be(true)
+    vpack.get("m").get("seq3").get(0).get("foo2").getAsInt should be(42)
+
+    vpack.get("m").get("seq4").get(0).isObject should be(true)
+    vpack.get("m").get("seq4").get(0).size should be(3)
+    vpack.get("m").get("seq4").get(0).get("foo3").isInt should be(true)
+    vpack.get("m").get("seq4").get(0).get("foo3").getAsInt should be(42)
+
+    vpack.get("m").get("seq5").get(0).isObject should be(true)
+    vpack.get("m").get("seq5").get(0).size should be(4)
+    vpack.get("m").get("seq5").get(0).get("foo4").isInt should be(true)
+    vpack.get("m").get("seq5").get(0).get("foo4").getAsInt should be(42)
+
   }
 
   test("deserialize map") {
     val builder = new VPackBuilder
-    builder add ValueType.OBJECT
-    builder add ("m", ValueType.OBJECT)
-    builder add ("s", "hello world")
-    builder add ("i", new Integer(69))
+    builder.add(ValueType.OBJECT)
+    builder.add("m", ValueType.OBJECT)
+    builder.add("s", "hello world")
+    builder.add("i", Integer.valueOf(69))
     builder.close
     builder.close
 
@@ -118,12 +145,4 @@ class VPackMapTest extends FunSuite with Matchers {
     entity.m.get("s") should be(Some("hello world"))
     entity.m.get("i") should be(Some(69))
   }
-}
-
-object VPackMapTest {
-
-  object HashTrieMap {
-    def apply[A, B](pairs: (A, B)*): Map[A, B] = new HashMap.HashTrieMap(0, Array(HashMap(pairs: _*)), pairs.size)
-  }
-
 }

--- a/src/test/scala/com/arangodb/velocypack/module/scala/VPackOptionTest.scala
+++ b/src/test/scala/com/arangodb/velocypack/module/scala/VPackOptionTest.scala
@@ -2,9 +2,8 @@ package com.arangodb.velocypack.module.scala
 
 import scala.beans.BeanProperty
 
-import org.scalatest.Finders
-import org.scalatest.FunSuite
-import org.scalatest.Matchers
+import org.scalatest.funsuite._
+import org.scalatest.matchers._
 
 import com.arangodb.velocypack.VPack
 import com.arangodb.velocypack.VPackBuilder
@@ -16,7 +15,7 @@ case class OptionTestEntity(@BeanProperty var s: Option[String] = Option.empty,
   def this() = this(s = Option.empty)
 }
 
-class VPackOptionTest extends FunSuite with Matchers {
+class VPackOptionTest extends AnyFunSuite with should.Matchers {
 
   test("serialize Option") {
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()
@@ -51,11 +50,11 @@ class VPackOptionTest extends FunSuite with Matchers {
 
   test("deserialize null") {
     val builder = new VPackBuilder()
-    builder add ValueType.OBJECT
-    builder add ("s", ValueType.NULL)
-    builder add ("i", ValueType.NULL)
-    builder add ("o", ValueType.NULL)
-    builder close
+    builder.add(ValueType.OBJECT)
+    builder.add("s", ValueType.NULL)
+    builder.add("i", ValueType.NULL)
+    builder.add("o", ValueType.NULL)
+    builder.close
 
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()
     val entity: OptionTestEntity = vp.deserialize(builder.slice, classOf[OptionTestEntity])

--- a/src/test/scala/com/arangodb/velocypack/module/scala/VPackSeqTest.scala
+++ b/src/test/scala/com/arangodb/velocypack/module/scala/VPackSeqTest.scala
@@ -3,7 +3,9 @@ package com.arangodb.velocypack.module.scala
 import java.{util => ju}
 
 import com.arangodb.velocypack.{VPack, VPackBuilder, ValueType}
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite._
+import org.scalatest.matchers._
+
 
 import scala.beans.BeanProperty
 
@@ -15,7 +17,7 @@ case class WrappedSeqTestEntity(map: Map[String, Any], seq: Seq[Any], opt: Optio
   def this() = this(Map.empty, Nil, None)
 }
 
-class VPackSeqTest extends FunSuite with Matchers {
+class VPackSeqTest extends AnyFunSuite with should.Matchers {
 
   test("serialize seq") {
     val vp = new VPack.Builder().registerModule(new VPackScalaModule).build()


### PR DESCRIPTION
Fixes #15 

Adds support for more map types, specifically anonymous ones that are instantiated when calling methods like:
- `Map.withDefault()` or `Map.withDefaultValue()`
- `Map.filterKeys()`
- `Map.mapValues()`

The fix was tested with Scala 2.11 and 2.12